### PR TITLE
Apply ros2 force message on operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,35 @@ Run the cage simulation of a human figure with attached tendons.
 ```bash
 ros2 run bulletroboy cage_simulation  # see node help for execution modes
 ```
+
+## Running the loop.
+
+# The Operator:
+To test the operator reacting to the collisions message (currently created with fake publisher in test_publisher.py) follow these instructions:
+
+- open three terminals and in each of them run the following lines of code:
+
+```bash
+cd roboy_ws
+source /opt/ros/eloquent/setup.bash
+. install/setup.bash
+cd src/bulletroboy/bulletroboy
+```
+- Now in the first terminal run to initiate the collisions message (test) publisher:
+
+```bash
+python3 test_publisher.py
+```
+
+- In the second terminal run this line to check the running ros2 collisions message:
+
+```bash
+ros2 topic echo /roboy/exoforce/collisions
+```
+
+- In the third terminal run this line. (The operator may move strangely due to the test_publisher message - it should work better with the loop feedback and the real message)
+
+```bash
+python3 cage_simulation.py -m forces
+```
+

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ros2 run bulletroboy cage_simulation  # see node help for execution modes
 ## Running the loop.
 
 # The Operator:
-To test the operator reacting to the collisions message (currently created with fake publisher in test_publisher.py) follow these instructions:
+To test the operator reacting to the collisions message follow these instructions:
 
 - open three terminals and in each of them run the following lines of code:
 
@@ -58,7 +58,7 @@ source /opt/ros/eloquent/setup.bash
 . install/setup.bash
 cd src/bulletroboy/bulletroboy
 ```
-- Now in the first terminal run to initiate the collisions message (test) publisher:
+- Now in the first terminal run this line to initiate the collisions message (test) publisher:
 
 ```bash
 python3 test_publisher.py
@@ -70,7 +70,7 @@ python3 test_publisher.py
 ros2 topic echo /roboy/exoforce/collisions
 ```
 
-- In the third terminal run this line. (The operator may move strangely due to the test_publisher message - it should work better with the loop feedback and the real message)
+- In the third terminal run this line. (Curretly, the operator follows the collisions message from test_publisher. Once its merged with the other loop components this will change.)
 
 ```bash
 python3 cage_simulation.py -m forces

--- a/bulletroboy/cage_simulation.py
+++ b/bulletroboy/cage_simulation.py
@@ -52,7 +52,7 @@ def main():
     # RUN SIM
     try:
         while True:
-            exoforce.operator.move(FOREARM_ROLL)
+            # exoforce.operator.move(FOREARM_ROLL)
             exoforce.update()
             p.stepSimulation()
 

--- a/bulletroboy/exoforce_simulation.py
+++ b/bulletroboy/exoforce_simulation.py
@@ -53,18 +53,13 @@ class ExoForceSim(ExoForce):
 		force = forces.normalforce
 		vector = forces.contactnormal
 
-		"""force_vec = Vector3()
-		force_vec.x = force * vector.x
-		force_vec.y = force * vector.y
-		force_vec.z = force * vector.z"""
-
 		force_vec = [force * vector.x, force * vector.y, force * vector.z]
 		position_vec = [forces.position.x, forces.position.y, forces.position.z]
 
 		self.apply_force_on_op(forces.linkid, force_vec, position_vec)
 
 	def apply_force_on_op(self, linkid, force_vec, position):
-		print("force_vec = ", force_vec)
+		#print("force_vec = ", force_vec)
 		p.applyExternalForce(self.operator.body_id, linkid, force_vec,
 				     position, p.WORLD_FRAME)
 
@@ -87,15 +82,6 @@ class ExoForceSim(ExoForce):
 	def update_tendon(self, id, force):
 		self.get_muscle_unit(id).force = force
 		if force > 0: self.get_tendon_sim(id).apply_force(force)
-
-	def update_reaction(self, linkname, posOnBody, contNormal, contDist, normalForce):
-		self.operator.get_link_index(linkname)
-		p.applyExternalForce(self.operator.body_id,
-				     self.operator.get_link_index(linkname),
-				     contNormal, #Maybe this needs to be multiplied with normalForce? Test checks.
-				     posOnBody,
-				     p.LINK_FRAME) # Because message is defined from link_frame.
-
 
 	def get_tendon_sim(self, id):
 		tendon_sim = None
@@ -136,6 +122,7 @@ class TendonSim():
 	def apply_force(self, force):
 		# TODO: apply forces to all via points, currently the force is applied to the last via point
 		force_direction = np.asarray(self.start_location) - np.asarray(self.tendon.attachtment_points[-1])
+		# print("start location: ", self.start_location)
 		force_direction /= norm(force_direction)
 
 		p.applyExternalForce(objectUniqueId=self.operator.body_id,

--- a/bulletroboy/exoforce_simulation.py
+++ b/bulletroboy/exoforce_simulation.py
@@ -58,10 +58,13 @@ class ExoForceSim(ExoForce):
 
 		self.apply_force_on_op(forces.linkid, force_vec, position_vec)
 
-	def apply_force_on_op(self, linkid, force_vec, position):
-		#print("force_vec = ", force_vec)
-		p.applyExternalForce(self.operator.body_id, linkid, force_vec,
-				     position, p.WORLD_FRAME)
+	def apply_force_on_op(self, linkid, force_vec, position_on_link):
+		body_id = self.operator.body_id
+		link_pos = list(p.getLinkState(body_id, linkid)[0])
+		force_position = [sum(x) for x in zip(link_pos, position_on_link)]
+		print("force_position: ", force_position)
+
+		p.applyExternalForce(body_id, linkid, force_vec, force_position, p.WORLD_FRAME)
 
 
 	def update(self):		
@@ -122,7 +125,6 @@ class TendonSim():
 	def apply_force(self, force):
 		# TODO: apply forces to all via points, currently the force is applied to the last via point
 		force_direction = np.asarray(self.start_location) - np.asarray(self.tendon.attachtment_points[-1])
-		# print("start location: ", self.start_location)
 		force_direction /= norm(force_direction)
 
 		p.applyExternalForce(objectUniqueId=self.operator.body_id,

--- a/bulletroboy/operator.py
+++ b/bulletroboy/operator.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 from numpy.linalg import norm
 from termcolor import colored
+from roboy_simulation_msgs.msg import Collision
 
 
 class Operator():
@@ -14,6 +15,7 @@ class Operator():
 		self.body_id = body_id
 		self.links = self.get_links()
 		self.movements = Movements(self)
+		self.create_subscription(Collision, '/roboy/simulation/operator/contacts', self.force_mapper_listener, 10)
 
 	def get_links(self):
 		links = []
@@ -41,6 +43,10 @@ class Operator():
 	
 	def move(self, case):
 		self.movements.simple_move(case)
+
+	def force_mapper_listener(self, contact_info):
+		self.apply_forces(contact_info)		# There is already an apply forces function. Use it!!
+		
 
 
 class Movements():

--- a/bulletroboy/operator.py
+++ b/bulletroboy/operator.py
@@ -1,21 +1,29 @@
 import pybullet as p
 import time
 import math
+import rclpy
 import numpy as np
+
+from rclpy.node import Node
 from numpy.linalg import norm
 from termcolor import colored
-from roboy_simulation_msgs.msg import Collision
+from roboy_simulation_msgs.msg import TendonUpdate
+from geometry_msgs.msg import PoseStamped
 
 
-class Operator():
+
+class Operator(Node):
 	def __init__(self, body_id):
 		"""
 		This class handles the operator body and its links in the simulation.
 		"""
+		super().__init__("operator_node")		
 		self.body_id = body_id
 		self.links = self.get_links()
 		self.movements = Movements(self)
-		self.create_subscription(Collision, '/roboy/simulation/operator/contacts', self.force_mapper_listener, 10)
+		self.ef_publisher = self.create_publisher(PoseStamped, '/roboy/simulation/operator/pose/endeffector', 10)
+		
+
 
 	def get_links(self):
 		links = []
@@ -44,9 +52,27 @@ class Operator():
 	def move(self, case):
 		self.movements.simple_move(case)
 
-	def force_mapper_listener(self, contact_info):
-		self.apply_forces(contact_info)		# There is already an apply forces function. Use it!!
-		
+	def publish_state(self, ef_names = np.array(['human/left_hand','human/right_hand'])):
+
+		for ef in ef_names:
+		   msg = PoseStamped()
+		   ef_id = self.get_link_index(ef)
+		   link_info = p.getLinkState(self.body_id, ef_id)[:2]
+		   link_pos = link_info[0]
+		   link_orn = link_info[1]
+
+		   msg.header.frame_id = ef
+
+		   msg.pose.position.x = link_pos[0]
+		   msg.pose.position.y = link_pos[1]
+		   msg.pose.position.z = link_pos[2]
+
+		   msg.pose.orientation.x = link_orn[0]
+		   msg.pose.orientation.y = link_orn[1]
+		   msg.pose.orientation.z = link_orn[2]
+		   msg.pose.orientation.w = link_orn[3]
+
+		   self.ef_publisher.publish(msg)
 
 
 class Movements():
@@ -210,5 +236,3 @@ class Movements():
 
 		elif case == 4:
                     p.resetJointState(self.body_id, spine_side_link, math.sin(t))
-
-

--- a/bulletroboy/test_publisher.py
+++ b/bulletroboy/test_publisher.py
@@ -59,11 +59,11 @@ def main():
         contact_info.position.y = 0.0
         contact_info.position.z = 0.0
         contact_info.contactnormal = Vector3()
-        contact_info.contactnormal.x = 0.2*np.cos(t) + 0.8
-        contact_info.contactnormal.y = 0.2*np.sin(t) + 0.8
-        contact_info.contactnormal.z = 0.0
+        contact_info.contactnormal.x = 0.0
+        contact_info.contactnormal.y = 0.0
+        contact_info.contactnormal.z = 1.2*np.sin(t)
         contact_info.contactdistance = 0.0
-        contact_info.normalforce = 200.0
+        contact_info.normalforce = 350.0
 
         collision_message_publisher.publish(contact_info)
 

--- a/bulletroboy/test_publisher.py
+++ b/bulletroboy/test_publisher.py
@@ -2,7 +2,7 @@
 import rclpy
 from roboy_simulation_msgs.msg import TendonUpdate
 from roboy_simulation_msgs.msg import Collision
-from roboy_control_msgs.msg import CageState, MuscleUnit, ViaPoint
+# from roboy_control_msgs.msg import CageState, MuscleUnit, ViaPoint
 from geometry_msgs.msg import Point
 from geometry_msgs.msg import Vector3
 from std_msgs.msg import Float32
@@ -17,7 +17,7 @@ def main():
     #force_publisher = node.create_publisher(TendonUpdate, '/roboy/simulation/tendon_force', 10)
     #angle_publisher = node.create_publisher(Float32, '/roboy/simulation/cage_rotation', 10)
     #cage_state_publisher = node.create_publisher(CageState, '/roboy/simulation/cage_state', 10)
-    collision_message_publisher = node.create_publisher(Collision, '/roboy/simulation/operator/contacts', 10)
+    collision_message_publisher = node.create_publisher(Collision, '/roboy/exoforce/collisions', 10)
 
     while True:
 

--- a/bulletroboy/test_publisher.py
+++ b/bulletroboy/test_publisher.py
@@ -1,9 +1,14 @@
 
 import rclpy
 from roboy_simulation_msgs.msg import TendonUpdate
+from roboy_simulation_msgs.msg import Collision
 from roboy_control_msgs.msg import CageState, MuscleUnit, ViaPoint
 from geometry_msgs.msg import Point
+from geometry_msgs.msg import Vector3
 from std_msgs.msg import Float32
+
+from bulletroboy.operator import Operator
+import numpy as np
 import time
 
 def main():
@@ -11,7 +16,8 @@ def main():
     node = rclpy.create_node("test_publisher")
     #force_publisher = node.create_publisher(TendonUpdate, '/roboy/simulation/tendon_force', 10)
     #angle_publisher = node.create_publisher(Float32, '/roboy/simulation/cage_rotation', 10)
-    cage_state_publisher = node.create_publisher(CageState, '/roboy/simulation/cage_state', 10)
+    #cage_state_publisher = node.create_publisher(CageState, '/roboy/simulation/cage_state', 10)
+    collision_message_publisher = node.create_publisher(Collision, '/roboy/simulation/operator/contacts', 10)
 
     while True:
 
@@ -24,24 +30,42 @@ def main():
         # angle.data = 58.0
         # angle_publisher.publish(angle)
 
-        state = CageState()
-        state.rotation_angle = 47.8
-        for i in range(3):
-            muscleunit = MuscleUnit()
-            muscleunit.id = i
-            for i in range(2):
-                point = ViaPoint()
-                point.id = i
-                point.position = Point()
-                point.position.x = 0.0
-                point.position.y = 0.0
-                point.position.z = 0.0
-                point.reference_frame = 'world'
-                point.link = 'hand'
-                muscleunit.viapoints.append(point)
-            state.muscleunits.append(muscleunit)
+        # state = CageState()
+        # state.rotation_angle = 47.8
+        # for i in range(3):
+        #     muscleunit = MuscleUnit()
+        #     muscleunit.id = i
+        #     for i in range(2):
+        #         point = ViaPoint()
+        #         point.id = i
+        #         point.position = Point()
+        #         point.position.x = 0.0
+        #         point.position.y = 0.0
+        #         point.position.z = 0.0
+        #         point.reference_frame = 'world'
+        #         point.link = 'hand'
+        #         muscleunit.viapoints.append(point)
+        #     state.muscleunits.append(muscleunit)
 
-        cage_state_publisher.publish(state)
+        # cage_state_publisher.publish(state)
+
+        """I know these are magic numbers but its just for testing :)"""
+
+        t = time.time()
+        contact_info = Collision()
+        contact_info.linkid = 25
+        contact_info.position = Vector3()
+        contact_info.position.x = 0.0
+        contact_info.position.y = 0.0
+        contact_info.position.z = 0.0
+        contact_info.contactnormal = Vector3()
+        contact_info.contactnormal.x = 0.0
+        contact_info.contactnormal.y = 0.0
+        contact_info.contactnormal.z = 0.2*np.sin(t) + 1
+        contact_info.contactdistance = 0.0
+        contact_info.normalforce = 200.0
+
+        collision_message_publisher.publish(contact_info)
 
         time.sleep(0.1)
 

--- a/bulletroboy/test_publisher.py
+++ b/bulletroboy/test_publisher.py
@@ -59,9 +59,9 @@ def main():
         contact_info.position.y = 0.0
         contact_info.position.z = 0.0
         contact_info.contactnormal = Vector3()
-        contact_info.contactnormal.x = 0.0
-        contact_info.contactnormal.y = 0.0
-        contact_info.contactnormal.z = 0.2*np.sin(t) + 1
+        contact_info.contactnormal.x = 0.2*np.cos(t) + 0.8
+        contact_info.contactnormal.y = 0.2*np.sin(t) + 0.8
+        contact_info.contactnormal.z = 0.0
         contact_info.contactdistance = 0.0
         contact_info.normalforce = 200.0
 


### PR DESCRIPTION
This branch deals with the operator of the loop that connects roboy, the force_mapper and the operator. 

Here the operator receives a message of type collision from test_publisher.py (This file is a fake_publisher used for testing). Once this information is received, an external force as specified by the message is then applied on the operator.

**Things to take into account when running this code:**
1. The most up-to-date version of the collision.msg (that this code uses) is in the roboy_communication branch: dashing-ss20-EFC57-Collision_message. Hence for this code to work, it is first necessary to do a git checkout to this branch.
2. The README file explains how to run the code.
3. The code runs and works but the operator's reaction to the force application is not exactly how it should be. I have been stuck on this for a long time and I think it would probably be better to ask Alona. The issue is the following: When the msg sends a force vector (vec3 contactnormal) information like: (cos(t), 0, 0) the logical response of the operator should be a swing of the link in the x direction. Yet, it just moves once, and then does not swing. The collision message can be checked with the ros2 topic echo line specified in the readme and it seems to be correct. It must have to do with the applyexternalforce function (applied in the "apply_force_on_op" function, which is itself called from forces_update_listener) but I didnt find any implementation mistakes.
