### PR TITLE
Added service to get initial end efectors configuration

### DIFF
--- a/bulletroboy/exoforce.py
+++ b/bulletroboy/exoforce.py
@@ -14,111 +14,133 @@ from geometry_msgs.msg import Point
 
 
 class CageConfiguration():
-    def __init__(self, filepath=None):
-        """
-		This class handles the initial cage configuration.
-		It can read and write from an XML file.
+	"""This class handles the initial cage configuration.
+		It reads and writes from a XML file.
+	"""
+	def __init__(self, filepath=None):
 		"""
-        self.filepath = filepath
-        self.cage_structure = {}
-        self.muscle_units = []
+		Args:
+			filepath (string): Path to XML configuration file. Default None.
 
-        if self.filepath:
-            self.load(filepath)
+		"""
+		self.filepath = filepath
+		self.cage_structure = {}
+		self.muscle_units = []
+		
+		if self.filepath:
+			self.load(filepath)
 
-    def load(self, filepath):
-        # parsing XML file
-        tree = ET.parse(filepath)
-        root = tree.getroot()
+	def load(self, filepath):
+		# parsing XML file
+		tree = ET.parse(filepath)
+		root = tree.getroot()
 
-        # getting main items
-        cage_xml = root.find('cageStructure')
-        muscles_xml = root.find('muscleUnits')
+		# getting main items
+		cage_xml = root.find('cageStructure')
+		muscles_xml = root.find('muscleUnits')
 
-        # parsing cage structure
-        self.cage_structure['height'] = int(cage_xml.find('height').text)
-        self.cage_structure['radius'] = int(cage_xml.find('radius').text)
+		# parsing cage structure
+		self.cage_structure['height'] = float(cage_xml.find('height').text)
+		self.cage_structure['radius'] = float(cage_xml.find('radius').text)
 
-        # parsing muscle units
-        for muscle in muscles_xml:
-            muscle_dict = {}
-            muscle_dict['id'] = int(muscle.get('id'))
-            muscle_dict['viaPoints'] = []
-            for via_point_xml in muscle.find('viaPoints'):
-                via_point = {}
-                via_point['id'] = int(via_point_xml.get('id'))
-                via_point['link'] = via_point_xml.get('link')
-                via_point['point'] = np.array(list(map(float, via_point_xml.text.split(" "))))
-                muscle_dict['viaPoints'].append(via_point)
-            muscle_dict['parameters'] = {}
-            for parameter in muscle.find('parameters'):
-                muscle_dict['parameters'][parameter.tag] = parameter.text
-            self.muscle_units.append(muscle_dict)
+		# parsing muscle units
+		for muscle in muscles_xml:
+			muscle_dict = {}
+			muscle_dict['id'] = int(muscle.get('id'))
+			muscle_dict['viaPoints'] = []
+			for via_point_xml in muscle.find('viaPoints'):
+				via_point = {}
+				via_point['id'] = int(via_point_xml.get('id'))
+				via_point['link'] = via_point_xml.get('link')
+				via_point['point'] = np.array(list(map(float, via_point_xml.text.split(" "))))
+				muscle_dict['viaPoints'].append(via_point)
+			muscle_dict['parameters'] = {}
+			for parameter in muscle.find('parameters'):
+				muscle_dict['parameters'][parameter.tag] = parameter.text
+			self.muscle_units.append(muscle_dict)
 
-    def save(self, filepath=None):
-        if filepath is None: filepath = self.filepath
+	def save(self, filepath=None):
+		if filepath is None: filepath = self.filepath
 
-        # main item
-        cageConfiguration = ET.Element('cageConfiguration')
+		# main item
+		cageConfiguration = ET.Element('cageConfiguration')
 
-        # cageStructure
-        cage_xml = ET.SubElement(cageConfiguration, 'cageStructure')
-        cage_height = ET.SubElement(cage_xml, 'height')
-        cage_radius = ET.SubElement(cage_xml, 'radius')
-        cage_height.text = str(self.cage_structure['height'])
-        cage_radius.text = str(self.cage_structure['radius'])
+		# cageStructure
+		cage_xml = ET.SubElement(cageConfiguration, 'cageStructure')
+		cage_height = ET.SubElement(cage_xml, 'height')
+		cage_radius = ET.SubElement(cage_xml, 'radius')
+		cage_height.text = str(self.cage_structure['height'])
+		cage_radius.text = str(self.cage_structure['radius'])
 
-        # muscle Units
-        muscles_xml = ET.SubElement(cageConfiguration, 'muscleUnits')
-        for muscle in self.muscle_units:
-            muscle_xml = ET.SubElement(muscles_xml, 'muscleUnit')
-            muscle_xml.set('id', str(muscle['id']))
-            muscle_via_points = ET.SubElement(muscle_xml, 'viaPoints')
-            for via_point in muscle['viaPoints']:
-                via_point_xml = ET.SubElement(muscle_via_points, 'viaPoint')
-                via_point_xml.set('id', str(via_point['id']))
-                via_point_xml.set('link', via_point['link'])
-                via_point_xml.text = str(via_point['point'].tolist()).strip('[]').replace(',', '')
-            muscle_parameters = ET.SubElement(muscle_xml, 'parameters')
-            for k, v in muscle['parameters'].items():
-                subelement = ET.SubElement(muscle_parameters, k)
-                subelement.text = v
+		# muscle Units
+		muscles_xml = ET.SubElement(cageConfiguration, 'muscleUnits')
+		for muscle in self.muscle_units:
+			muscle_xml = ET.SubElement(muscles_xml, 'muscleUnit')
+			muscle_xml.set('id', str(muscle['id']))
+			muscle_via_points = ET.SubElement(muscle_xml, 'viaPoints')
+			for via_point in muscle['viaPoints']:
+				via_point_xml = ET.SubElement(muscle_via_points, 'viaPoint')
+				via_point_xml.set('id', str(via_point['id']))
+				via_point_xml.set('link', via_point['link'])
+				via_point_xml.text = str(via_point['point'].tolist()).strip('[]').replace(',', '')
+			muscle_parameters = ET.SubElement(muscle_xml, 'parameters')
+			for k, v in muscle['parameters'].items():
+				subelement = ET.SubElement(muscle_parameters, k)
+				subelement.text = v
 
-        # write to file
-        mydata = ET.tostring(cageConfiguration).decode()
-        reparsed = minidom.parseString(mydata)
-        mydata = reparsed.toprettyxml(indent="\t")
-        myfile = open(filepath, "w")
-        myfile.write(mydata)
-        myfile.close()
+		# write to file
+		mydata = ET.tostring(cageConfiguration).decode()
+		reparsed = minidom.parseString(mydata)
+		mydata = reparsed.toprettyxml(indent="\t")
+		myfile = open(filepath, "w")
+		myfile.write(mydata)
+		myfile.close()
 
-    def __str__(self):
-        msg = f"\nCAGE CONFIGURATION: ({self.filepath})\n"
-        msg += "-------------------\n"
-        msg += "Cage Structure:\n"
-        msg += f"\theight: {self.cage_structure['height']}\n"
-        msg += f"\tradius: {self.cage_structure['radius']}\n"
-        msg += "Muscle Units:\n"
-        for muscle in self.muscle_units:
-            msg += "\t-----------------\n"
-            msg += f"\tid: {muscle['id']}\n"
-            msg += "\tvia points:\n"
-            for via_point in muscle['viaPoints']:
-                msg += f"\t\t{via_point['id']} link: {via_point['link']:<20}\tpoint: {via_point['point']}\n"
-            msg += "\tparameters:\n"
-            for k, v in muscle['parameters'].items():
-                msg += f"\t\t{k}: {v}\n"
-        return msg
+	def __str__(self):
+		msg = f"\nCAGE CONFIGURATION: ({self.filepath})\n"
+		msg += "-------------------\n"
+		msg += "Cage Structure:\n"
+		msg += f"\theight: {self.cage_structure['height']}\n"
+		msg += f"\tradius: {self.cage_structure['radius']}\n"
+		msg += "Muscle Units:\n"
+		for muscle in self.muscle_units:
+			msg += "\t-----------------\n"
+			msg += f"\tid: {muscle['id']}\n"
+			msg += "\tvia points:\n"
+			for via_point in muscle['viaPoints']:
+				msg += f"\t\t{via_point['id']} link: {via_point['link']:<20}\tpoint: {via_point['point']}\n"
+			msg += "\tparameters:\n"
+			for k, v in muscle['parameters'].items():
+				msg += f"\t\t{k}: {v}\n"
+		return msg
 
 
 class ViaPoint():
+	"""This class handles tendon's via points.
+
+	"""
 	def __init__(self, via_point):
+		"""
+		Args:
+			via_point (dict): Via point's configuration defined in the configuration file.
+
+		"""
 		self.id = via_point['id']
 		self.link = via_point['link']
 		self.link_point = via_point['point']
 		self.world_point = via_point['point']
 
 	def to_msg(self, init_conf=False):
+		"""Returns via point data as a ROS message.
+		
+		Args:
+			init_conf (bool): If True the ROS message will include data from the configuration file,
+				if False, it will include current state data.
+
+		Returns:
+		   ViaPointMsg: ROS via point message definition.
+
+		"""
 		via_point_msg = ViaPointMsg()
 		via_point_msg.id = self.id
 		via_point_msg.position.x, via_point_msg.position.y, via_point_msg.position.z = self.link_point if init_conf else self.world_point
@@ -128,51 +150,69 @@ class ViaPoint():
 
 
 class Tendon():
+	"""This class handles each tendon attached to the operator.
+
+	"""
 	def __init__(self, id, motor, via_points):
 		"""
-		This class handles each tendon attached to the operator.
+		Args:
+			id (int): Id of the via point.
+			motor (Motor): Motor object to which the tendon is attached to.
+			via_points (List[ViaPoint]): Tendon via points which are attached to the operator.
+
 		"""
 		self.id = id
 		self.motor = motor
 		self.via_points = via_points
 
 	def update(self, operator):
+		"""Updates via points' world points according to operator state.
+		
+		Args:
+			operator (Operator): Operator object to which the tendon is attached.
+
+		Returns:
+			-
+
+		Todo:
+			* consider link orientation to get via point's world point
+
+		"""
 		for via_point in self.via_points:
 			via_point.world_point = operator.get_link_center(via_point.link) + via_point.link_point
 
 
-class Cage():
-	def __init__(self, height, radius, motors):
-		"""
-		This class handles the cage and the motors attached to it.
-		"""
-		self.origin = np.array([0, 0, 0])
-		self.height = height
-		self.radius = radius
-		self.angle = 0.0
-
-		self.motors = motors
-
-	def rotate_cage(self, new_angle):
-
-		for motor in self.motors:
-			motor.rotate(self.angle - new_angle, self.origin)
-
-		self.angle = new_angle
-
-
 class Motor():
+	"""This class handles a motor attached to the cage.
+
+	"""
 	def __init__(self, id, via_point):
 		"""
-		This class handles a motor attached to the cage.
+		Args:
+			id (int): Id of the motor.
+			via_point (ViaPoint): Point in which the motor is attached to the cage.
+		
+		Raises:
+			AssertionError: Via point link must be cage.
+		
 		"""
 		assert via_point.link == "cage"
 
 		self.id = id
 		self.via_point = via_point
-		self.force = 0
+		self.force = 0.0
 
 	def rotate(self, delta, pivot):
+		"""Updates motor's world position with rotation angle around a pivot point.
+		
+		Args:
+			delta (float): Rotation in degrees.
+			pivot (List[float]): Vector3 point around which the rotation is happening.
+
+		Returns:
+			-
+
+		"""
 
 		x, y = self.via_point.world_point[:2]
 		offset_x, offset_y = pivot[:2]
@@ -188,9 +228,16 @@ class Motor():
 
 
 class MuscleUnit():
+	"""This class handles a muscle unit including it's tendon and motor.
+
+	"""
 	def __init__(self, id, via_points, parameters):
 		"""
-		This class handles a muscle unit including its tendon and motor.
+		Args:
+			id (int): Id of the motor.
+			via_points (List[dict]): Via points' configuration defined in the configuration file.
+			parameters (dict): Muscle unit's parameters defined in the configuration file.
+		
 		"""
 		self.id = id
 		self.via_points = [ViaPoint(via_point) for via_point in via_points]
@@ -201,9 +248,28 @@ class MuscleUnit():
 		self.max_force = float(parameters['max_force'])
 
 	def set_motor_force(self, force):
+		"""Sets motor's current applied force.
+		
+		Args:
+			force (float): Force applied by motor.
+
+		Returns:
+			-
+
+		"""
 		self.motor.force = force
 
 	def to_msg(self, init_conf=False):
+		"""Returns muscle unit data as a ROS message.
+		
+		Args:
+			init_conf (bool): If 'True' the ROS message will include data from the configuration file,
+				if 'False', it will include current state data.
+
+		Returns:
+		   MuscleUnitMsg: ROS muscle unit message definition.
+
+		"""
 		muscle_msg = MuscleUnitMsg()
 		muscle_msg.id = self.id
 		if init_conf: muscle_msg.max_force = self.max_force
@@ -213,10 +279,51 @@ class MuscleUnit():
 		return muscle_msg
 
 
+class Cage():
+	"""This class handles the cage and the motors attached to it.
+	
+	"""
+	def __init__(self, height, radius, motors):
+		"""
+		Args:
+			height (float): Height of the cage in meters.
+			radius (float): Radius of the cage in meters.
+			motors (List[Motor]): Tendons' motors in the cage.
+
+		"""
+		self.origin = np.array([0, 0, 0])
+		self.height = height
+		self.radius = radius
+		self.angle = 0.0
+
+		self.motors = motors
+
+	def rotate_cage(self, new_angle):
+		"""Updates cage angle and motors' world positions with new angle.
+		
+		Args:
+			new_angle (float): New angle to which the cage is rotated in degrees.
+
+		Returns:
+			-
+
+		"""
+		for motor in self.motors:
+			motor.rotate(self.angle - new_angle, self.origin)
+
+		self.angle = new_angle
+
+
 class ExoForce(Node, ABC):
+	"""Main ExoForce class. It handles the muscle units and the cage itself.
+	
+	"""
 	def __init__(self, cage_conf, node_name):
 		"""
-		Main ExoForce class. It handles the muscle units and the cage itself.
+		Args:
+			cage_conf (CageConfiguration): Cage configuration defined in the configuration file.
+			node_name (string): Node name for ROS node's initialization.
+		
 		"""
 		super().__init__(node_name)
 		self.muscle_units = [ MuscleUnit(muscle['id'], muscle['viaPoints'], muscle['parameters'])
@@ -229,6 +336,15 @@ class ExoForce(Node, ABC):
 		self.initial_conf_service = self.create_service(GetCageEndEffectors, '/roboy/configuration/end_effectors', self.get_end_effectors_callback)
 	
 	def init_end_effectors(self):
+		"""Initializes end effectors list.
+		
+		Args:
+			-
+
+		Returns:
+		   -
+
+		"""
 		self.end_effectors = []
 		for muscle in self.muscle_units:
 			ef = muscle.end_effector.link
@@ -239,12 +355,27 @@ class ExoForce(Node, ABC):
 		pass
 
 	def rotate_cage(self, angle):
+		"""Applies cage rotation to a new angle.
+		
+		Args:
+			angle (float): New angle for cage rotation in degress.
+
+		Returns:
+		   	-
+
+		"""
 		self.cage.rotate_cage(angle)
 
-	def tendon_update(self, id, force):
-		self.get_muscle_unit(id).update(force)
-
 	def get_muscle_unit(self, id):
+		"""Gets ExoForce's muscle unit by id.
+		
+		Args:
+			id (int): Id of the muscle unit to search.
+
+		Returns:
+		   MuscleUnit: Muscle unit with given id.
+
+		"""
 		unit = None
 		for muscle in self.muscle_units:
 			if muscle.id == id:
@@ -253,19 +384,55 @@ class ExoForce(Node, ABC):
 		return unit
 	
 	def get_ef_muscle_units(self, end_effector):
+		"""Gets ExoForce's muscle units by end effector.
+		
+		Args:
+			end_effector (string): End effector name's to search for muscle units.
+
+		Returns:
+		   	List[MuscleUnit]: Muscle units with tendons attached to the given end effector.
+
+		"""
 		muscle_units = []
 		for muscle in self.muscle_units:
-			if muscle.end_effector == end_effector:
+			if muscle.end_effector.link == end_effector:
 				muscle_units.append(muscle)
 		return muscle_units
 
 	def get_motors(self):
+		"""Gets ExoForce's motors.
+		
+		Args:
+			-
+
+		Returns:
+			List[Motor]: ExoForce's motors.
+		
+		"""
 		return [ muscle.motor for muscle in self.muscle_units ]
 
 	def get_tendons(self):
+		"""Gets ExoForce's tendons.
+		
+		Args:
+			-
+
+		Returns:
+			List[Tendon]: ExoForce's tendons.
+		
+		"""
 		return [ muscle.tendon for muscle in self.muscle_units ]
 
 	def to_msg(self):
+		"""Returns ExoForce's data as a ROS message.
+		
+		Args:
+			-
+
+		Returns:
+		   CageState: ROS cage state message definition.
+
+		"""
 		state_msg = CageState()
 		state_msg.rotation_angle = self.cage.angle
 		for muscle in self.muscle_units:
@@ -275,10 +442,21 @@ class ExoForce(Node, ABC):
 		return state_msg
 
 	def publish_state(self):
+		"""Publishes ExoForce's state as a ROS message.
+		
+		Args:
+			-
+
+		Returns:
+		   	-
+
+		"""
 		self.cage_state_publisher.publish(self.to_msg())
 
 	def get_end_effectors_callback(self, request, response):
+		"""ROS service callback to get end effectors initial configuration.
 
+		"""
 		for ef in self.end_effectors:
 			end_effector_msg = EndEffector()
 			end_effector_msg.name = ef

--- a/bulletroboy/exoforce_simulation.py
+++ b/bulletroboy/exoforce_simulation.py
@@ -94,7 +94,7 @@ class TendonSim():
 
 		self.force_id = None
 
-		self.start_location = self.tendon.motor.pos
+		self.start_location = self.tendon.motor.via_point.world_point
 		self.segments = []
 
 		self.init_lines()
@@ -102,7 +102,7 @@ class TendonSim():
 	def init_lines(self):
 		start = self.start_location
 		for via_point in self.tendon.via_points:
-			point = self.operator.get_link_center(via_point['link']) + via_point['point']
+			point = self.operator.get_link_center(via_point.link) + via_point.link_point
 			segment = p.addUserDebugLine(start, point, lineColorRGB=self.debug_color, lineWidth=2)
 			self.segments.append(segment)
 			start = point
@@ -114,14 +114,15 @@ class TendonSim():
 		force_direction /= norm(force_direction)
 
 		p.applyExternalForce(objectUniqueId=self.operator.body_id,
-			     	     linkIndex = self.operator.get_link_index(self.tendon.via_points[-1]['link']),
+			     	     linkIndex = self.operator.get_link_index(self.tendon.via_points[-1].link),
 			     	     forceObj = force * force_direction,
 			     	     posObj=self.start_location,
 			     	     flags=p.WORLD_FRAME)
 
 	def update_lines(self):
 		start = self.start_location
-		for segment, point in zip(self.segments, self.tendon.attachtment_points):
+		for segment, via_point in zip(self.segments, self.tendon.via_points):
+			point = via_point.world_point
 			p.addUserDebugLine(start, point, lineColorRGB=self.debug_color, lineWidth=2, replaceItemUniqueId=segment)
 			start = point
 		p.addUserDebugText(self.name, self.start_location, self.debug_color, textSize=0.8, replaceItemUniqueId=self.debug_text)

--- a/bulletroboy/exoforce_simulation.py
+++ b/bulletroboy/exoforce_simulation.py
@@ -11,9 +11,16 @@ from bulletroboy.operator import Operator
 
 
 class ExoForceSim(ExoForce):
+	"""ExoForce Child class. This class handles the simulation of the exoforce.
+
+	"""
 	def __init__(self, cage_conf, human_model, mode):
 		"""
-		ExoForce Child class. This class handles the simulation of the exoforce.
+		Args:
+			cage_conf (CageConfiguration): Cage configuration defined in the configuration file.
+			human_model (int): Id of the human model loaded in pybullet.
+			mode (string): Mode in which the ExoForceSim will we executed.
+		
 		"""
 		super().__init__(cage_conf, "exoforce_simulation")
 
@@ -32,12 +39,30 @@ class ExoForceSim(ExoForce):
 			self.create_subscription(Float32, '/roboy/simulation/cage_rotation', self.cage_rotation_listener, 10)
 
 	def init_sim(self):
+		"""Initializes simulation.
+		
+		Args:
+			-
+
+		Returns:
+		   -
+
+		"""
 		self.sim_tendons = []
 		for tendon in self.get_tendons():
 			new_tendon = TendonSim(tendon, self.operator)
 			self.sim_tendons.append(new_tendon)
 
 	def init_debug_parameters(self):
+		"""Initializes pybullet debug parameters.
+		
+		Args:
+			-
+
+		Returns:
+		   -
+
+		"""
 		for tendon_sim in self.sim_tendons:
 			tendon_sim.force_id = p.addUserDebugParameter("Force in " + tendon_sim.name, 0, 200, 0)
 		self.cage_angle_id = p.addUserDebugParameter("Cage Angle", -180, 180, 0)
@@ -52,7 +77,16 @@ class ExoForceSim(ExoForce):
         # TODO: implement force update
 		pass
 
-	def update(self):		
+	def update(self):
+		"""Update ExoForce's state after a simulation step.
+		
+		Args:
+			-
+
+		Returns:
+		   	-
+
+		"""	
 		for tendon_sim in self.sim_tendons:
 			tendon_sim.tendon.update(self.operator)
 			tendon_sim.update_lines()
@@ -69,10 +103,29 @@ class ExoForceSim(ExoForce):
 
 
 	def update_tendon(self, id, force):
+		"""Applies a force to a tendon in the simulation.
+		
+		Args:
+			id (int): Id of the tendon to update.
+			force (float): Force applied to the tendon.
+
+		Returns:
+		   	-
+
+		"""
 		self.get_muscle_unit(id).force = force
 		if force > 0: self.get_tendon_sim(id).apply_force(force)
 
 	def get_tendon_sim(self, id):
+		"""Gets ExoForceSim's tendon by id.
+		
+		Args:
+			id (int): Id of the tendon simulation to search.
+
+		Returns:
+		   TendonSim: Tendon simulation with given id.
+
+		"""
 		tendon_sim = None
 		for tendon in self.sim_tendons:
 			if tendon.tendon.id == id:
@@ -82,9 +135,15 @@ class ExoForceSim(ExoForce):
 
 
 class TendonSim():
+	"""This class handles the simulation of each tendon attached to the operator.
+	
+	"""
 	def __init__(self, tendon, operator):
 		"""
-		This class handles the simulation of each tendon attached to the operator.
+		Args:
+			tendon (Tendon): ExoForce's tendon to be simulated.
+			operator (Operator): Operator object to which the tendon is attached.
+		
 		"""
 		self.tendon = tendon
 		self.name = "Tendon " + str(self.tendon.id)
@@ -100,6 +159,15 @@ class TendonSim():
 		self.init_lines()
 
 	def init_lines(self):
+		"""Initializes debug lines for each via point.
+		
+		Args:
+			-
+
+		Returns:
+		   -
+
+		"""
 		start = self.start_location
 		for via_point in self.tendon.via_points:
 			point = self.operator.get_link_center(via_point.link) + via_point.link_point
@@ -109,7 +177,19 @@ class TendonSim():
 		self.debug_text = p.addUserDebugText(self.name, self.start_location, textColorRGB=self.debug_color, textSize=0.8)
 
 	def apply_force(self, force):
-		# TODO: apply forces to all via points, currently the force is applied to the last via point
+		"""Applies force to the simulated operator.
+		
+		Args:
+			force (float): Force to be applied.
+
+		Returns:
+		   -
+
+		Todo:
+			* apply forces to all via points, currently the force is applied to the last via point (end effector)
+			* move method to the Operator class
+
+		"""
 		force_direction = np.asarray(self.start_location) - np.asarray(self.tendon.attachtment_points[-1])
 		force_direction /= norm(force_direction)
 
@@ -120,6 +200,15 @@ class TendonSim():
 			     	     flags=p.WORLD_FRAME)
 
 	def update_lines(self):
+		"""Update debug lines position in simulation.
+		
+		Args:
+			-
+
+		Returns:
+		   -
+
+		"""
 		start = self.start_location
 		for segment, via_point in zip(self.segments, self.tendon.via_points):
 			point = via_point.world_point

--- a/bulletroboy/test_client.py
+++ b/bulletroboy/test_client.py
@@ -25,7 +25,9 @@ def main():
                 for ef in response.end_efectors:
                     node.get_logger().info(f"{ef.name} tendons {len(ef.muscle_units)}:")
                     for muscle in ef.muscle_units:
-                        node.get_logger().info(f"id [{muscle.id}] max_force [{muscle.max_force}] points [{muscle.viapoints[0].position}]")
+                        node.get_logger().info(f"muscle [{muscle.id}] max_force [{muscle.max_force}]")
+                        for via_point in muscle.viapoints:
+                            node.get_logger().info(f"via_point [{via_point.id}] reference_frame [{via_point.reference_frame}] link [{via_point.link}] point [{via_point.position}]")
 
             break
 

--- a/bulletroboy/test_client.py
+++ b/bulletroboy/test_client.py
@@ -1,16 +1,16 @@
 import rclpy
-from roboy_control_msgs.srv import GetCageEndEfectors
+from roboy_control_msgs.srv import GetCageEndEffectors
 import time
 
 def main():
     rclpy.init()
     node = rclpy.create_node("test_client")
-    cli = node.create_client(GetCageEndEfectors, '/roboy/configuration/end_efectors')
+    cli = node.create_client(GetCageEndEffectors, '/roboy/configuration/end_effectors')
 
     while not cli.wait_for_service(timeout_sec=1.0):
             node.get_logger().info('service not available, waiting again...')
 
-    req = GetCageEndEfectors.Request()
+    req = GetCageEndEffectors.Request()
     res = cli.call_async(req)
 
     while rclpy.ok():
@@ -22,7 +22,7 @@ def main():
                 node.get_logger().info(
                     'Service call failed %r' % (e,))
             else:
-                for ef in response.end_efectors:
+                for ef in response.end_effectors:
                     node.get_logger().info(f"{ef.name} tendons {len(ef.muscle_units)}:")
                     for muscle in ef.muscle_units:
                         node.get_logger().info(f"muscle [{muscle.id}] max_force [{muscle.max_force}]")

--- a/bulletroboy/test_client.py
+++ b/bulletroboy/test_client.py
@@ -1,0 +1,34 @@
+import rclpy
+from roboy_control_msgs.srv import GetCageEndEfectors
+import time
+
+def main():
+    rclpy.init()
+    node = rclpy.create_node("test_client")
+    cli = node.create_client(GetCageEndEfectors, '/roboy/configuration/end_efectors')
+
+    while not cli.wait_for_service(timeout_sec=1.0):
+            node.get_logger().info('service not available, waiting again...')
+
+    req = GetCageEndEfectors.Request()
+    res = cli.call_async(req)
+
+    while rclpy.ok():
+        rclpy.spin_once(node)
+        if res.done():
+            try:
+                response = res.result()
+            except Exception as e:
+                node.get_logger().info(
+                    'Service call failed %r' % (e,))
+            else:
+                for ef in response.end_efectors:
+                    node.get_logger().info(f"{ef.name} tendons {len(ef.muscle_units)}:")
+                    for muscle in ef.muscle_units:
+                        node.get_logger().info(f"id [{muscle.id}] max_force [{muscle.max_force}] points [{muscle.viapoints[0].position}]")
+
+            break
+
+if __name__ == '__main__':
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         'console_scripts': [
             'ros2_roboy = bulletroboy.ros2_roboy:main',
             'cage_simulation = bulletroboy.cage_simulation:main',
-            'test_publisher = bulletroboy.test_publisher:main'
+            'test_publisher = bulletroboy.test_publisher:main',
+            'test_client = bulletroboy.test_client:main'
         ],
     },
 )


### PR DESCRIPTION
A service was added in ExoForce class (cage_simulation node) to allow other nodes to retrieve the initial configuration from the XML file.
The first via_point of each muscle unit (motor position)  is not included in the response, given that this changes which cage rotation and its part of the cage state, NOT initial configuration.

The cage state publisher was modified to not publish the via_points attached to the operator, it only publishes the first via_point (motor position).